### PR TITLE
using sed to get the correct img url

### DIFF
--- a/playcheck.sh
+++ b/playcheck.sh
@@ -4,7 +4,7 @@ img_url=""
 
 while :
 do
-   new_img_url=$(playerctl metadata mpris:artUrl 2>/dev/null)
+   new_img_url=$(playerctl metadata mpris:artUrl 2>/dev/null | sed s/open.spotify.com/i.scdn.co/)
    if [[ "$new_img_url" != "$img_url" ]]
    then
       linktype=$(echo "$new_img_url" | awk -F "://" '{print$1}')


### PR DESCRIPTION
`playerctl metadata mpris:artUrl` points to an incorrect [url](https://open.spotify.com/image/ab67616d00001e023a927e16c14f2aeb7c004e19).

I used `sed` to change the url to the correct [one](https://i.scdn.co/image/ab67616d00001e023a927e16c14f2aeb7c004e19).

old url: open.spotify.com
new url: i.scdn.co

About how I get the new url, I used inspect element on spotify web player to find it.